### PR TITLE
[#12] Skip predicate creation for default labels

### DIFF
--- a/src/main/java/org/s1ck/gdl/GDLHandler.java
+++ b/src/main/java/org/s1ck/gdl/GDLHandler.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Helper class that wraps ANTLR initialization logic.
@@ -97,7 +98,7 @@ public class GDLHandler {
    *
    * @return predicates
    */
-  public Predicate getPredicates() { return loader.getPredicates(); }
+  public Optional<Predicate> getPredicates() { return loader.getPredicates(); }
 
   /**
    * Returns the graph cache that contains a mapping from variables used in the GDL script to

--- a/src/main/java/org/s1ck/gdl/GDLLoader.java
+++ b/src/main/java/org/s1ck/gdl/GDLLoader.java
@@ -34,7 +34,6 @@ import org.s1ck.gdl.utils.Comparator;
 
 import java.util.*;
 
-
 class GDLLoader extends GDLBaseListener {
 
   // used to cache elements which are used with variables
@@ -153,11 +152,13 @@ class GDLLoader extends GDLBaseListener {
   }
 
     /**
-     * Returns the predicates defined by the query or {@code null} if no predicates are declared.
+     * Returns the predicates defined by the query.
      *
      * @return predicates
      */
-  Predicate getPredicates() { return predicates; }
+  Optional<Predicate> getPredicates() {
+    return predicates != null ? Optional.of(predicates) : Optional.empty();
+  }
   /**
    * Returns the graph cache that contains a mapping from variables used in the GDL script to
    * graph instances.

--- a/src/main/java/org/s1ck/gdl/GDLLoader.java
+++ b/src/main/java/org/s1ck/gdl/GDLLoader.java
@@ -153,7 +153,7 @@ class GDLLoader extends GDLBaseListener {
   }
 
     /**
-     * Returns the predicates defined by the query
+     * Returns the predicates defined by the query or {@code null} if no predicates are declared.
      *
      * @return predicates
      */
@@ -229,10 +229,10 @@ class GDLLoader extends GDLBaseListener {
   @Override
   public void exitQuery(GDLParser.QueryContext ctx) {
     for(Vertex v : vertices) {
-      addPredicates(Predicate.fromGraphElement(v));
+      addPredicates(Predicate.fromGraphElement(v, getDefaultVertexLabel()));
     }
     for(Edge e : edges) {
-      addPredicates(Predicate.fromGraphElement(e));
+      addPredicates(Predicate.fromGraphElement(e, getDefaultEdgeLabel()));
     }
   }
 
@@ -707,8 +707,6 @@ class GDLLoader extends GDLBaseListener {
    * @param newPredicates predicates to be added
    */
   private void addPredicates(List<Predicate> newPredicates) {
-
-
     for(Predicate newPredicate : newPredicates) {
       if(this.predicates == null) {
         this.predicates = newPredicate;

--- a/src/main/java/org/s1ck/gdl/model/predicates/Predicate.java
+++ b/src/main/java/org/s1ck/gdl/model/predicates/Predicate.java
@@ -32,7 +32,7 @@ import java.util.Set;
 /**
  * Represents a predicate defined on a query vertex or edge.
  */
-public interface Predicate extends Serializable{
+public interface Predicate extends Serializable {
 
   /**
    * Builds predicates from label and property definitions embedded at an
@@ -41,12 +41,12 @@ public interface Predicate extends Serializable{
    * @param element the element to extract from
    * @return extracted predicates
    */
-  static List<Predicate> fromGraphElement(GraphElement element) {
+  static List<Predicate> fromGraphElement(GraphElement element, String defaultLabel) {
     ArrayList<Predicate> predicates = new ArrayList<>();
 
     Predicate predicate;
 
-    if(element.getLabel() != null && !element.getLabel().equals("")) {
+    if(element.getLabel() != null && !element.getLabel().equals(defaultLabel)) {
       predicate = new Comparison(
         new PropertySelector(element.getVariable(),"__label__"),
         Comparator.EQ,
@@ -71,13 +71,15 @@ public interface Predicate extends Serializable{
 
   /**
    * Returns the predicates arguments
+   *
    * @return The predicates arguments
    */
-  public Predicate[] getArguments();
+  Predicate[] getArguments();
 
   /**
    * Returns the variables which are referenced by the predicate
+   *
    * @return referenced variables
    */
-  public Set<String> getVariables();
+  Set<String> getVariables();
 }

--- a/src/main/java/org/s1ck/gdl/model/predicates/booleans/And.java
+++ b/src/main/java/org/s1ck/gdl/model/predicates/booleans/And.java
@@ -36,8 +36,7 @@ public class And implements Predicate {
 
   @Override
   public Predicate[] getArguments() {
-    Predicate[] arguments = {lhs,rhs};
-    return arguments;
+    return new Predicate[] { lhs, rhs };
   }
 
   /**
@@ -54,6 +53,6 @@ public class And implements Predicate {
 
   @Override
   public String toString() {
-    return "(" + lhs + " AND " + rhs + ")";
+    return String.format("(%s AND %s)", lhs, rhs);
   }
 }

--- a/src/main/java/org/s1ck/gdl/model/predicates/booleans/Not.java
+++ b/src/main/java/org/s1ck/gdl/model/predicates/booleans/Not.java
@@ -46,6 +46,6 @@ public class Not implements Predicate {
 
   @Override
   public String toString() {
-    return "( NOT " + expression + " )";
+    return String.format("(NOT %s)", expression);
   }
 }

--- a/src/main/java/org/s1ck/gdl/model/predicates/booleans/Or.java
+++ b/src/main/java/org/s1ck/gdl/model/predicates/booleans/Or.java
@@ -36,8 +36,7 @@ public class Or implements Predicate {
 
   @Override
   public Predicate[] getArguments() {
-    Predicate[] arguments = {lhs,rhs};
-    return arguments;
+    return new Predicate[] { lhs, rhs };
   }
 
   /**
@@ -54,6 +53,6 @@ public class Or implements Predicate {
 
   @Override
   public String toString() {
-    return "(" + lhs + " OR " + rhs + ")";
+    return String.format("(%s OR %s)", lhs, rhs);
   }
 }

--- a/src/main/java/org/s1ck/gdl/model/predicates/booleans/Xor.java
+++ b/src/main/java/org/s1ck/gdl/model/predicates/booleans/Xor.java
@@ -36,8 +36,7 @@ public class Xor implements Predicate {
 
   @Override
   public Predicate[] getArguments() {
-    Predicate[] arguments = {lhs,rhs};
-    return arguments;
+    return new Predicate[] { lhs, rhs };
   }
 
   /**
@@ -54,6 +53,6 @@ public class Xor implements Predicate {
 
   @Override
   public String toString() {
-    return "(" + lhs + " XOR " + rhs + ")";
+    return String.format("(%s XOR %s)", lhs, rhs);
   }
 }

--- a/src/test/java/org/s1ck/gdl/GDLLoaderTest.java
+++ b/src/test/java/org/s1ck/gdl/GDLLoaderTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import static org.junit.Assert.*;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 public class GDLLoaderTest {
 
   // --------------------------------------------------------------------------------------------
@@ -330,7 +331,7 @@ public class GDLLoaderTest {
     GDLLoader loader = getLoaderFromGDLString(query);
     validateCollectionSizes(loader, 0, 2, 1);
 
-    assertNull(loader.getPredicates());
+    assertFalse(loader.getPredicates().isPresent());
   }
 
   @Test
@@ -341,7 +342,7 @@ public class GDLLoaderTest {
     GDLLoader loader = getLoaderFromGDLString(query);
     validateCollectionSizes(loader, 0, 2, 1);
 
-    assertEquals("alice.age > 50", loader.getPredicates().toString());
+    assertEquals("alice.age > 50", loader.getPredicates().get().toString());
   }
 
   @Test
@@ -352,7 +353,7 @@ public class GDLLoaderTest {
     GDLLoader loader = getLoaderFromGDLString(query);
     validateCollectionSizes(loader, 0, 2, 1);
 
-    assertEquals("(NOT alice.age > 50)", loader.getPredicates().toString());
+    assertEquals("(NOT alice.age > 50)", loader.getPredicates().get().toString());
   }
 
   @Test
@@ -364,7 +365,7 @@ public class GDLLoaderTest {
     validateCollectionSizes(loader, 0, 2, 1);
 
     assertEquals("((alice.age > bob.age OR (alice.age < 30 AND bob.name = Bob)) AND alice.id != bob.id)",
-      loader.getPredicates().toString());
+      loader.getPredicates().get().toString());
   }
 
   @Test
@@ -375,7 +376,7 @@ public class GDLLoaderTest {
     validateCollectionSizes(loader, 0, 2, 1);
 
     assertEquals("((alice.age = 50 AND bob.__label__ = User) AND r.__label__ = knows)",
-      loader.getPredicates().toString());
+      loader.getPredicates().get().toString());
   }
 
   @Test
@@ -393,9 +394,9 @@ public class GDLLoaderTest {
         " AND other.__label__ = Person)" +
         " AND e1.__label__ = likes)" +
         " AND e1.love = true)",
-      loader.getPredicates().toString());
+      loader.getPredicates().get().toString());
 
-    assertEquals("vertex p has wrong label","Person",p.getLabel());
+    assertEquals("vertex p has wrong label","Person", p.getLabel());
   }
 
   @Test(expected=InvalidReferenceException.class)


### PR DESCRIPTION
* skipping predicate creation if no label and no properties are present at the GraphElement
* using Optional to return Predicates from `GDLLoader` and `GDLHandler`
* adapted tests
* fixes #12 