### PR TITLE
[#25] Add support for multiple vertex (and graph) labels

### DIFF
--- a/src/main/antlr4/org/s1ck/gdl/GDL.g4
+++ b/src/main/antlr4/org/s1ck/gdl/GDL.g4
@@ -65,7 +65,7 @@ edgeLength
     ;
 
 header
-    : Identifier? label?
+    : Identifier? label*
     ;
 
 properties

--- a/src/main/java/org/s1ck/gdl/model/Edge.java
+++ b/src/main/java/org/s1ck/gdl/model/Edge.java
@@ -16,6 +16,8 @@
 
 package org.s1ck.gdl.model;
 
+import java.util.List;
+
 public class Edge extends GraphElement {
   private Long sourceVertexId;
 
@@ -65,6 +67,14 @@ public class Edge extends GraphElement {
 
   public void setUpperBound(int upperBound) {
     this.upperBound = upperBound;
+  }
+
+  @Override
+  public void setLabels(List<String> labels) {
+    if(labels.size() > 1) {
+      throw new RuntimeException("Edges can only have one label");
+    }
+    super.setLabels(labels);
   }
 
   @Override

--- a/src/main/java/org/s1ck/gdl/model/Edge.java
+++ b/src/main/java/org/s1ck/gdl/model/Edge.java
@@ -70,14 +70,6 @@ public class Edge extends GraphElement {
   }
 
   @Override
-  public void setLabels(List<String> labels) {
-    if(labels.size() > 1) {
-      throw new RuntimeException("Edges can only have one label");
-    }
-    super.setLabels(labels);
-  }
-
-  @Override
   public String toString() {
     String out = "Edge{" +
       "id=" + getId() +

--- a/src/main/java/org/s1ck/gdl/model/Element.java
+++ b/src/main/java/org/s1ck/gdl/model/Element.java
@@ -16,14 +16,16 @@
 
 package org.s1ck.gdl.model;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Element {
 
   private Long id;
 
-  private String label;
+  private List<String> labels;
 
   private Map<String, Object> properties;
 
@@ -42,11 +44,19 @@ public class Element {
   }
 
   public String getLabel() {
-    return label;
+    return this.labels.get(0);
   }
 
   public void setLabel(String label) {
-    this.label = label;
+    this.labels = Collections.singletonList(label);
+  }
+
+  public List<String> getLabels() {
+    return this.labels;
+  }
+
+  public void setLabels(List<String> labels) {
+    this.labels = labels;
   }
 
   public String getVariable() {

--- a/src/main/java/org/s1ck/gdl/model/predicates/Predicate.java
+++ b/src/main/java/org/s1ck/gdl/model/predicates/Predicate.java
@@ -45,6 +45,7 @@ public interface Predicate extends Serializable {
 
     Predicate predicate;
 
+    //TODO respect multiple labels
     if(element.getLabel() != null && !element.getLabel().equals(defaultLabel)) {
       predicate = new Comparison(
         new PropertySelector(element.getVariable(),"__label__"),

--- a/src/test/java/org/s1ck/gdl/GDLLoaderTest.java
+++ b/src/test/java/org/s1ck/gdl/GDLLoaderTest.java
@@ -174,9 +174,16 @@ public class GDLLoaderTest {
     assertEquals("edge has wrong label", "hasInterest", e.getLabel());
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void readEdgeWithMultipleLabelsTest() {
-    getLoaderFromGDLString("()-[e:hasInterest:foobar]->()");
+    GDLLoader loader = getLoaderFromGDLString("()-[e:hasInterest:foobar]->()");
+    Edge e = loader.getEdgeCache().get("e");
+    assertEquals(
+      "edge has wrong label",
+      Arrays.asList("hasInterest", "foobar"), e.getLabels()
+    );
+
+    assertEquals("hasInterest", e.getLabel());
   }
 
   @Test

--- a/src/test/java/org/s1ck/gdl/GDLLoaderTest.java
+++ b/src/test/java/org/s1ck/gdl/GDLLoaderTest.java
@@ -39,7 +39,8 @@ public class GDLLoaderTest {
 
     Optional<Vertex> vertex = loader.getVertices().stream().findFirst();
     assertTrue(vertex.isPresent());
-    assertEquals(loader.getDefaultVertexLabel(), vertex.get().getLabel());
+    assertEquals(1, vertex.get().getLabels().size());
+    assertEquals(loader.getDefaultVertexLabel(), vertex.get().getLabels().get(0));
   }
 
   @Test
@@ -58,7 +59,18 @@ public class GDLLoaderTest {
   public void readVertexWithLabelTest() {
     GDLLoader loader = getLoaderFromGDLString("(var:Label)");
     Vertex v = loader.getVertexCache().get("var");
-    assertEquals("vertex has wrong label", "Label", v.getLabel());
+    assertEquals("vertex has wrong label", "Label", v.getLabels().get(0));
+  }
+
+  @Test
+  public void readVertexWithMultipleLabelsTest() {
+    GDLLoader loader = getLoaderFromGDLString("(var:Label1:Label2:Label3)");
+    Vertex v = loader.getVertexCache().get("var");
+    assertEquals(
+      "vertex has wrong label",
+      Arrays.asList("Label1", "Label2", "Label3"), v
+      .getLabels()
+    );
   }
 
   @Test
@@ -151,6 +163,7 @@ public class GDLLoaderTest {
     GDLLoader loader = getLoaderFromGDLString("()-[e:knows]->()");
     Edge e = loader.getEdgeCache().get("e");
     assertFalse("edge should not have variable length", e.hasVariableLength());
+    assertEquals("edge has the wrong number of labels", 1, e.getLabels().size());
     assertEquals("edge has wrong label", "knows", e.getLabel());
   }
 
@@ -159,6 +172,11 @@ public class GDLLoaderTest {
     GDLLoader loader = getLoaderFromGDLString("()-[e:hasInterest]->()");
     Edge e = loader.getEdgeCache().get("e");
     assertEquals("edge has wrong label", "hasInterest", e.getLabel());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void readEdgeWithMultipleLabelsTest() {
+    getLoaderFromGDLString("()-[e:hasInterest:foobar]->()");
   }
 
   @Test
@@ -238,7 +256,8 @@ public class GDLLoaderTest {
 
     Optional<Graph> graph = loader.getGraphs().stream().findFirst();
     assertTrue(graph.isPresent());
-    assertEquals(loader.getDefaultGraphLabel(), graph.get().getLabel());
+    assertEquals(1, graph.get().getLabels().size());
+    assertEquals(loader.getDefaultGraphLabel(), graph.get().getLabels().get(0));
   }
 
   @Test
@@ -271,6 +290,7 @@ public class GDLLoaderTest {
       1, 0, 0,
       0, 1, 0);
     Graph g = loader.getGraphCache().get("g");
+    assertEquals("graph has the wrong number of labels", 1, g.getLabels().size());
     assertEquals("graph has wrong label", "Label", g.getLabel());
   }
 
@@ -279,6 +299,17 @@ public class GDLLoaderTest {
     GDLLoader loader = getLoaderFromGDLString("g:LabelParty[()]");
     Graph g = loader.getGraphCache().get("g");
     assertEquals("graph has wrong label", "LabelParty", g.getLabel());
+  }
+
+  @Test
+  public void readGraphWithMultipleLabelsTest() {
+    GDLLoader loader = getLoaderFromGDLString("g:Label1:Label2[()]");
+    Graph g = loader.getGraphCache().get("g");
+    assertEquals(
+      "graph has wrong label",
+      Arrays.asList("Label1", "Label2"),
+      g.getLabels()
+    );
   }
 
   @Test


### PR DESCRIPTION
Fixes #25 

* Adds support for multiple vertex labels
* legacy methods for `GraphElement.getLabel()` returns the first label in the list
* as part of this graphs and edges can also have multiple labels

✔️ Gradoop tests pass